### PR TITLE
Fix getInfo() deprecation

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -90,7 +90,7 @@ class Loader
         $query_args,
         AbstractConnectionResolver $resolver
     ) {
-        $info = $resolver->getInfo();
+        $info = $resolver->get_info();
         $selection_set = $info->getFieldSelection(2);
 
         if (!isset($selection_set['pageInfo']['offsetPagination']['total'])) {


### PR DESCRIPTION
`PHP Deprecated: Function WPGraphQL\\Data\\Connection\\AbstractConnectionResolver::getInfo is deprecated since version 1.24.0! Use WPGraphQL\\Data\\Connection\\PostObjectConnectionResolver::get_info() instead.`